### PR TITLE
Fix bug with xml output of alternate names

### DIFF
--- a/plugins/PluginCertInfo.py
+++ b/plugins/PluginCertInfo.py
@@ -224,7 +224,7 @@ class PluginCertInfo(PluginBase.PluginBase):
         
         val_xml = Element('extensions')
         alt_name_xml = self._subject_alternative_name_to_xml(alt_name)
-        val_xml.append(alt_name_xml)
+        val_xml.extend(alt_name_xml)
         return ([alt_name_txt],[val_xml])
         
 


### PR DESCRIPTION
_subject_alternative_name_to_xml() returns a list. When this list was appended to the extensions node, xml output would thrown an exception.
