### PR TITLE
CRL verification support

### DIFF
--- a/plugins/PluginCertInfo.py
+++ b/plugins/PluginCertInfo.py
@@ -217,9 +217,10 @@ class PluginCertInfo(PluginBase.PluginBase):
 
     interface.add_command(
         command="crl",
-        help= "Verifies the certificate ID against the CRL pointed to by the certificate. "
-            "CRL should be set to 'crl'.",
-        dest="crl")
+        help= "Verify that the certificate ID against the CRL pointed "
+             "to by the certificate is accessible and that the certificate "
+             "is not revoked.",
+        dest=None)
 
 
     FIELD_FORMAT = '      {0:<35}{1:<35}'
@@ -256,9 +257,9 @@ class PluginCertInfo(PluginBase.PluginBase):
 
         
         # Text output
-        if arg == 'basic':
+        if self._shared_settings['certinfo'] == 'basic':
             cert_txt = self._get_basic_text(cert, cert_dict)
-        elif arg == 'full':
+        elif self._shared_settings['certinfo'] == 'full':
             cert_txt = [cert.as_text()]
         else:
             raise Exception("PluginCertInfo: Unknown command.")

--- a/plugins/PluginCertInfo.py
+++ b/plugins/PluginCertInfo.py
@@ -265,7 +265,7 @@ class PluginCertInfo(PluginBase.PluginBase):
         # Create text result for any CRL checks done.
         if self._shared_settings['crl']:
             if self.crl_result['verified']:
-                crl_result_text = "Certificate not revoked in CRL."
+                crl_result_text = "Certificate not revoked in CRL"
             elif 'uri_error' in self.crl_result:
                 crl_result_text = "Problem loading CRL. " + self.crl_result['uri_error']
             else:

--- a/plugins/PluginCertInfo.py
+++ b/plugins/PluginCertInfo.py
@@ -239,6 +239,11 @@ class PluginCertInfo(PluginBase.PluginBase):
         fingerprint = cert.get_fingerprint()
         cmd_title = 'Certificate'
         txt_result = [self.PLUGIN_TITLE_FORMAT.format(cmd_title)]
+
+        if self._shared_settings['sni']:
+            sni_text = 'SNI enabled with virtual domain ' + self._shared_settings['sni']
+            txt_result.append(self.FIELD_FORMAT.format("SNI:", sni_text))
+        
         trust_txt = 'Certificate is Trusted' if is_cert_trusted \
                                              else 'Certificate is NOT Trusted'
 
@@ -271,6 +276,9 @@ class PluginCertInfo(PluginBase.PluginBase):
                           'hasMatchingHostname' : str(host_xml)}
         if untrusted_reason:
             trust_xml_attr['reasonWhyNotTrusted'] = untrusted_reason
+
+        if self._shared_settings['sni']:
+            trust_xml_attr['sni'] = self._shared_settings['sni']
             
         trust_xml = Element('certificate', attrib = trust_xml_attr)
         

--- a/plugins/PluginCertInfo.py
+++ b/plugins/PluginCertInfo.py
@@ -215,8 +215,8 @@ class PluginCertInfo(PluginBase.PluginBase):
             "the certificate. CERTINFO should be 'basic' or 'full'.",
         dest="certinfo")
 
-    interface.add_command(
-        command="crl",
+    interface.add_option(
+        option="crl",
         help= "Verify that the certificate ID against the CRL pointed "
              "to by the certificate is accessible and that the certificate "
              "is not revoked.",
@@ -313,6 +313,14 @@ class PluginCertInfo(PluginBase.PluginBase):
 
         if self._shared_settings['sni']:
             trust_xml_attr['sni'] = self._shared_settings['sni']
+
+        if self._shared_settings['crl']:
+            if self.crl_result['verified']:
+                trust_xml_attr['crl'] = "verified"
+            elif 'uri_error' in self.crl_result:
+                trust_xml_attr['crl'] = self.crl_result['uri_error']
+            else:
+                trust_xml_attr['crl'] = "revoked"
             
         trust_xml = Element('certificate', attrib = trust_xml_attr)
         

--- a/plugins/PluginCertInfo.py
+++ b/plugins/PluginCertInfo.py
@@ -437,7 +437,7 @@ class PluginCertInfo(PluginBase.PluginBase):
 
         # Finally check if the give ID is in the CRL.
         if self.cert_id.lower() in self.crl_db:
-            self.crl_result[self.cert_id.lower()] = self.crl_db[cert_id.lower()]
+            self.crl_result[self.cert_id.lower()] = self.crl_db[self.cert_id.lower()]
         else:
             self.crl_result['verified'] = True
 

--- a/plugins/crl/README.txt
+++ b/plugins/crl/README.txt
@@ -1,0 +1,1 @@
+This is the local CRL cache directory.

--- a/utils/ctSSL/README
+++ b/utils/ctSSL/README
@@ -1,10 +1,13 @@
-Work in progress...
-ctSSL is released under the MIT license.  See the LICENSE file for details.
+SSLyze's very own ctypes-based OpenSSL wrapper. 
+https://github.com/iSECPartners/sslyze/
 
-Copyright (c) 2011 Alban Diquet
+Mostly untested and in the process of being deprecated because OpenSSL and
+ctypes do not work well together.
+
+ctSSL is released under the MIT license.  See the LICENSE file for details.
 
 Prerequisites: 
 	Python 2.6 or 2.7 and OpenSSL 0.9.8+.
 
-http://code.google.com/p/ctssl/
-
+Copyright (c) 2011 Alban Diquet
+https://github.com/nabla-c0d3


### PR DESCRIPTION
This patch adds optional CRL verification functionality.
If given --crl option when performing --certinfo, the plugin will look at the CRL uri in the cert, download the CRL, parse it and check if the cert ID is present in the CRL or not.

For performance reasons, the patch also implements a local, file based CRL cache. CRLs previously seen are not downloaded. Instead file with parsed and extracted revocation information is loaded. Finally, for CRL URIs that fail to load are also cached to remove repeated failed retrieval attempts when testing multiple domains.

Usage note:
Since CRL files are updated frequently, the generated files stored in the plugins/crl directory should be removed before a test session.
