### PR TITLE
Auto starttls

### DIFF
--- a/plugins/PluginHSTS.py
+++ b/plugins/PluginHSTS.py
@@ -1,3 +1,32 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#-------------------------------------------------------------------------------
+# Name:         PluginHSTS.py
+# Purpose:      Checks if the server supports RFC 6797 HTTP Strict Transport
+#               Security by checking if the server responds with the
+#               Strict-Transport-Security field in the header.
+#
+#               This plugin was written by Tom Samstag (tecknicaltom) and
+#               integrated, adapted by Joachim Strömbergson
+#
+# Author:       tecknicaltom, joachims
+#
+# Copyright:    2013 SSLyze developers
+#
+#   SSLyze is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation, either version 2 of the License, or
+#   (at your option) any later version.
+#
+#   SSLyze is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with SSLyze.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+
 from xml.etree.ElementTree import Element
 import socket
 
@@ -6,12 +35,12 @@ from utils.ctSSL import ctSSL_initialize, ctSSL_cleanup
 
 class PluginHSTS(PluginBase.PluginBase):
 
-    available_commands = PluginBase.AvailableCommands(
-        title="PluginHSTS",
-        description="Prints out the HSTS header details")
-    available_commands.add_command(
+    interface = PluginBase.PluginInterface(title="PluginHSTS", description=(''))
+    interface.add_command(
         command="hsts",
-        help="Help text for HSTS",
+        help="Verifies the support of a server for HTTP Strict Transport Security "
+             "(HSTS) by collecting any Strict-Transport-Security field present in "
+             "the response from the server.",
         dest=None)
 
     def process_task(self, target, command, args):

--- a/plugins/PluginHSTS.py
+++ b/plugins/PluginHSTS.py
@@ -6,8 +6,11 @@
 #               Security by checking if the server responds with the
 #               Strict-Transport-Security field in the header.
 #
-#               This plugin was written by Tom Samstag (tecknicaltom) and
-#               integrated, adapted by Joachim Strömbergson
+#               Note: There is currently no support for hsts pinning.
+#
+#               This plugin is based on the plugin written by Tom Samstag
+#               (tecknicaltom) and reworked, integrated and adapted to the
+#               new sslyze plugin API by Joachim Strömbergson.
 #
 # Author:       tecknicaltom, joachims
 #

--- a/plugins/PluginHSTS.py
+++ b/plugins/PluginHSTS.py
@@ -1,0 +1,50 @@
+from xml.etree.ElementTree import Element
+import socket
+
+from plugins import PluginBase
+from utils.ctSSL import ctSSL_initialize, ctSSL_cleanup
+
+class PluginHSTS(PluginBase.PluginBase):
+
+    available_commands = PluginBase.AvailableCommands(
+        title="PluginHSTS",
+        description="Prints out the HSTS header details")
+    available_commands.add_command(
+        command="hsts",
+        help="Help text for HSTS",
+        dest=None)
+
+    def process_task(self, target, command, args):
+
+        output_format = '        {0:<25} {1}'
+
+        ctSSL_initialize()
+        ssl_connect = self._create_ssl_connection(target)
+
+        header = None
+
+        #try: # Perform the SSL handshake
+        ssl_connect.connect()
+        ssl_connect.request("HEAD", "/", headers={"Connection": "close"})
+        http_response = ssl_connect.getresponse()
+        header = http_response.getheader('Strict-Transport-Security', None)
+
+        ctSSL_cleanup()
+
+        # Text output
+        cmd_title = 'HSTS'
+        txt_result = [self.PLUGIN_TITLE_FORMAT.format(cmd_title)]
+        txt_result.append(output_format.format("Strict-Transport-Security header:", header))
+
+        # XML output
+        xml_hsts_attr = {'header_found': str(header != None)}
+        if header:
+            xml_hsts_attr['header'] = header
+        xml_hsts = Element('hsts', attrib = xml_hsts_attr)
+        
+        xml_result = Element(self.__class__.__name__, command = command,
+                             title = cmd_title)
+        xml_result.append(xml_hsts)
+
+        return PluginBase.PluginResult(txt_result, xml_result)
+

--- a/sslyze.py
+++ b/sslyze.py
@@ -35,7 +35,7 @@ SSLYZE_VERSION = 'SSLyze v0.7 beta'
 DEFAULT_NB_PROCESSES = 5
 DEFAULT_TIMEOUT =   5
 PROJECT_URL = "https://github.com/isecPartners/sslyze"
-STARTTLS_PORTS = {25:'smtp', 587:'smtp', 5222:'xmpp', 5269:'xmpp'}
+STARTTLS_PORTS = {25:'smtp', 443:'https', 587:'smtp', 5222:'xmpp', 5269:'xmpp'}
 
 # Todo: Move formatting stuff to another file
 SCAN_FORMAT = 'Scan Results For {0}:{1} - {2}:{1}'

--- a/sslyze.py
+++ b/sslyze.py
@@ -35,6 +35,7 @@ SSLYZE_VERSION = 'SSLyze v0.7 beta'
 DEFAULT_NB_PROCESSES = 5
 DEFAULT_TIMEOUT =   5
 PROJECT_URL = "https://github.com/isecPartners/sslyze"
+STARTTLS_PORTS = {25:'smtp', 587:'smtp', 5222:'xmpp', 5269:'xmpp'}
 
 # Todo: Move formatting stuff to another file
 SCAN_FORMAT = 'Scan Results For {0}:{1} - {2}:{1}'
@@ -141,7 +142,9 @@ def main():
     except CommandLineParsingError as e:
         print e.get_error_msg()
         return
-    
+
+
+    shared_settings['starttls_ports'] = STARTTLS_PORTS
 
     #--PROCESSES INITIALIZATION--
     if command_list.https_tunnel:
@@ -164,10 +167,10 @@ def main():
     print _format_title('Checking host(s) availability')
 
     if command_list.https_tunnel:
-        targets_tester = ProxyConnectivityTester(target_list, 
+        targets_tester = ProxyConnectivityTester(shared_settings, target_list, 
                                                  command_list.https_tunnel)
     else:
-        targets_tester = ServersConnectivityTester(target_list, 
+        targets_tester = ServersConnectivityTester(shared_settings, target_list, 
                                                    command_list.starttls,
                                                    command_list.xmpp_to)
 

--- a/utils/CommandLineParser.py
+++ b/utils/CommandLineParser.py
@@ -180,7 +180,9 @@ class CommandLineParser():
             help= (
                 'Identifies the target server(s) as a SMTP or an XMPP server(s) '
                 'and scans the server(s) using STARTTLS. '
-                'STARTTLS should be \'smtp\' or \'xmpp\'.'),
+                'STARTTLS should be \'smtp\' or \'xmpp\'. '
+                'Alternatively \'auto\' can be given and the protocol will be '
+                'selected based on the given port number.'),
             dest='starttls',
             default=None)
     

--- a/utils/CommandLineParser.py
+++ b/utils/CommandLineParser.py
@@ -280,9 +280,9 @@ class CommandLineParser():
             shared_settings['https_tunnel_port'] = None
             
         # STARTTLS
-        if args_command_list.starttls not in [None,'smtp','xmpp']:
+        if args_command_list.starttls not in [None,'auto','smtp','xmpp']:
             raise CommandLineParsingError(
-                '--starttls should be \'smtp\' or \'xmpp\'.')
+                '--starttls should be \'smtp\', \'xmpp\' or \'auto\'.')
         
         if args_command_list.starttls and args_command_list.https_tunnel:
             raise CommandLineParsingError(

--- a/utils/SSLyzeSSLConnection/__init__.py
+++ b/utils/SSLyzeSSLConnection/__init__.py
@@ -151,6 +151,20 @@ class SSLyzeSSLConnection:
                 xmpp_to = host
                 
             ssl_connection = XMPPConnection(host, port, ssl, timeout, xmpp_to)   
+
+        # Remap to correct service based on port when starttls auto is used.
+        elif shared_settings['starttls'] == 'auto':
+            service = shared_settings['starttls_ports'][port]
+            if service == 'smtp':
+                ssl_connection = SMTPConnection(host, port, ssl, timeout)
+                    
+            elif service == 'xmpp':
+                if shared_settings['xmpp_to']:
+                    xmpp_to = shared_settings['xmpp_to']
+                else:
+                    xmpp_to = host
+                ssl_connection = XMPPConnection(host, port, ssl, timeout, xmpp_to)   
+            
                  
         elif shared_settings['https_tunnel_host']:
             # Using an HTTP CONNECT proxy to tunnel SSL traffic

--- a/utils/SSLyzeSSLConnection/__init__.py
+++ b/utils/SSLyzeSSLConnection/__init__.py
@@ -166,7 +166,8 @@ class SSLyzeSSLConnection:
                 else:
                     xmpp_to = host
                 ssl_connection = XMPPConnection(host, port, ssl, timeout, xmpp_to)   
-            
+            else:
+                ssl_connection = HTTPSConnection(host, port, ssl, timeout=timeout)
                  
         elif shared_settings['https_tunnel_host']:
             # Using an HTTP CONNECT proxy to tunnel SSL traffic

--- a/utils/ServersConnectivityTester.py
+++ b/utils/ServersConnectivityTester.py
@@ -182,10 +182,6 @@ class ServersConnectivityTester(ConnectivityTester):
             if len(target_port) == 2:
                 if int(target_port[1]) in self._starttls_ports:
                     self._starttls = self._starttls_ports[int(target_port[1])]
-                else:
-                    print "Error: %d is not a known STARTTLS port number." % int(target_port[1])
-            else:
-                print "Error: Missing port number in STARTTLS auto mode."
         
         if self._starttls == 'smtp':
             server_test = SMTPServerTester(target)

--- a/utils/ServersConnectivityTester.py
+++ b/utils/ServersConnectivityTester.py
@@ -181,8 +181,16 @@ class ServersConnectivityTester(ConnectivityTester):
         if self._starttls == 'auto':
             if len(target_port) == 2:
                 if int(target_port[1]) in self._starttls_ports:
-                    self._starttls = self._starttls_ports[int(target_port[1])]
-        
+                    service = self._starttls_ports[int(target_port[1])]
+                    if service == 'smtp':
+                        server_test = SMTPServerTester(target)
+                    elif service == 'xmpp':
+                        server_test = XMPPServerTester(target, self._xmpp_to)
+                    else:
+                        server_test = SSLServerTester(target)
+            else:
+                server_test = SSLServerTester(target)
+                
         if self._starttls == 'smtp':
             server_test = SMTPServerTester(target)
         elif self._starttls == 'xmpp':

--- a/utils/ServersConnectivityTester.py
+++ b/utils/ServersConnectivityTester.py
@@ -172,6 +172,17 @@ class ServersConnectivityTester(ConnectivityTester):
           
  
     def _test_server(self, target, timeout):
+        starttls_ports = {25:'smtp', 587:'smtp', 5222:'xmpp', 5269:'xmpp'}
+        target_port = target.split(':')
+        
+        if self._starttls == 'auto':
+            if len(target_port) == 2:
+                if int(target_port[1]) in starttls_ports:
+                    self._starttls = starttls_ports[int(target_port[1])]
+                else:
+                    print "Error: %d is not a known STARTTLS port number." % int(target_port[1])
+            else:
+                print "Error: Missing port number in STARTTLS auto mode."
         
         if self._starttls == 'smtp':
             server_test = SMTPServerTester(target)
@@ -179,7 +190,7 @@ class ServersConnectivityTester(ConnectivityTester):
             server_test = XMPPServerTester(target, self._xmpp_to)
         else:
             server_test = SSLServerTester(target)
-            
+
         return server_test.test_connectivity(timeout)
 
 

--- a/utils/ServersConnectivityTester.py
+++ b/utils/ServersConnectivityTester.py
@@ -72,8 +72,9 @@ class ProxyConnectivityTester(ConnectivityTester):
                          'proxy; discarding all tasks.')
     PROXY_OK_FORMAT = '\n   {0:<35}  => {1} - Proxy OK'
     
-    def __init__(self, target_list, proxy_str):
+    def __init__(self, shared_settings, target_list, proxy_str):
         
+        self._shared_settings = shared_settings
         self._target_list = target_list
         self._proxy_str = proxy_str
         self._result_str = ''
@@ -121,14 +122,15 @@ class ServersConnectivityTester(ConnectivityTester):
 
     TARGET_OK_FORMAT = '\n   {0:<35} => {1}'
 
-    def __init__(self, target_list, starttls=None, xmpp_to=None):
+    def __init__(self, shared_settings, target_list, starttls=None, xmpp_to=None):
         
+        self._shared_settings = shared_settings
         self._target_list = target_list
         self._starttls = starttls
         self._xmpp_to = xmpp_to
         self._targets_OK = []
         self._targets_ERR = []
-
+        
    
     def test_connectivity(self,  timeout):
         """
@@ -172,13 +174,14 @@ class ServersConnectivityTester(ConnectivityTester):
           
  
     def _test_server(self, target, timeout):
-        starttls_ports = {25:'smtp', 587:'smtp', 5222:'xmpp', 5269:'xmpp'}
+        self._starttls_ports = self._shared_settings['starttls_ports']
         target_port = target.split(':')
-        
+
+        # Rewrite the starttls parameter based on port if set to auto.
         if self._starttls == 'auto':
             if len(target_port) == 2:
-                if int(target_port[1]) in starttls_ports:
-                    self._starttls = starttls_ports[int(target_port[1])]
+                if int(target_port[1]) in self._starttls_ports:
+                    self._starttls = self._starttls_ports[int(target_port[1])]
                 else:
                     print "Error: %d is not a known STARTTLS port number." % int(target_port[1])
             else:

--- a/utils/ServersConnectivityTester.py
+++ b/utils/ServersConnectivityTester.py
@@ -300,7 +300,7 @@ class SMTPServerTester(SSLServerTester):
         if '250 ' not in s.recv(2048):
             raise InvalidTargetError(self._target_str, self.ERR_SMTP_REJECTED)
                 
-        # Semd a STARTTLS
+        # Send a STARTTLS
         s.send('STARTTLS\r\n')
         smtp_resp = s.recv(2048)
         if 'Ready to start TLS'  not in smtp_resp:


### PR DESCRIPTION
This patch updates sslyze to support an auto mode for STARTTLS. when --starttls=auto, sslyze will use the given port number to select the correct service to use.
