### PR TITLE
Ocsp support

### DIFF
--- a/plugins/PluginCertInfo.py
+++ b/plugins/PluginCertInfo.py
@@ -261,7 +261,7 @@ class PluginCertInfo(PluginBase.PluginBase):
 
         if self._shared_settings['ocsp']:
             if not self.ocsp_result['OCSP_PRESENT']:
-                ocsp_result_text = "OCSP Responder not in certificate"
+                ocsp_result_text = "No OCSP Responder in certificate"
             else:
                 if self.ocsp_result['verified']:
                     ocsp_result_text = "Certificate not revoked"

--- a/plugins/PluginCertInfo.py
+++ b/plugins/PluginCertInfo.py
@@ -241,7 +241,7 @@ class PluginCertInfo(PluginBase.PluginBase):
         cert_parsed = X509CertificateHelper(cert)
         cert_dict = cert_parsed.parse_certificate()
 
-        # Perform CRL checking if the option has been selected.
+        # Perform OCSP checking if the option has been selected.
         if self._shared_settings['ocsp']:
             self.ocsp_result = self._check_ocsp(cert_dict)            
         

--- a/plugins/PluginCertInfo.py
+++ b/plugins/PluginCertInfo.py
@@ -264,12 +264,11 @@ class PluginCertInfo(PluginBase.PluginBase):
                 ocsp_result_text = "OCSP Responder not in certificate"
             else:
                 if self.ocsp_result['verified']:
-                    ocsp_result_text = "Certificate verified by OCSP"
+                    ocsp_result_text = "Certificate not revoked"
                 elif 'uri_error' in self.ocsp_result:
                     ocsp_result_text = "Problem loading OCSP Issuer CA. " + self.ocsp_result['uri_error']
                 else:
-                    ocsp_result_text = "Cerificate not verified by OCSP %s " % \
-                                       self.ocsp_result['response'][0]
+                    ocsp_result_text = "Cerificate revoked"
             txt_result.append(self.FIELD_FORMAT.format("OCSP verification:", ocsp_result_text))
 
 

--- a/plugins/PluginCertInfo.py
+++ b/plugins/PluginCertInfo.py
@@ -206,6 +206,12 @@ class PluginCertInfo(PluginBase.PluginBase):
             "the certificate. CERTINFO should be 'basic' or 'full'.",
         dest="certinfo")
 
+    interface.add_option(
+        option="ocsp",
+        help= "Verify the certificate against the OCSP responder the "
+              "certificate points to.",
+        dest=None)
+
     FIELD_FORMAT = '      {0:<35}{1:<35}'
     
     def process_task(self, target, command, arg):

--- a/plugins/ocsp/README.txt
+++ b/plugins/ocsp/README.txt
@@ -1,0 +1,1 @@
+Local cache for OCSP checking.

--- a/utils/ctSSL/README
+++ b/utils/ctSSL/README
@@ -1,10 +1,13 @@
-Work in progress...
-ctSSL is released under the MIT license.  See the LICENSE file for details.
+SSLyze's very own ctypes-based OpenSSL wrapper. 
+https://github.com/iSECPartners/sslyze/
 
-Copyright (c) 2011 Alban Diquet
+Mostly untested and in the process of being deprecated because OpenSSL and
+ctypes do not work well together.
+
+ctSSL is released under the MIT license.  See the LICENSE file for details.
 
 Prerequisites: 
 	Python 2.6 or 2.7 and OpenSSL 0.9.8+.
 
-http://code.google.com/p/ctssl/
-
+Copyright (c) 2011 Alban Diquet
+https://github.com/nabla-c0d3


### PR DESCRIPTION
This patch adds support for OCSP validation to the CertInfo plugin.

The patch use OpenSSL as an external program to perform the cert transformation and OCSP validation.
In order to improve the performance the patch implements a local cert cache.
