### PR TITLE
Only look at response code for STARTTLS.

### DIFF
--- a/utils/SSLyzeSSLConnection.py
+++ b/utils/SSLyzeSSLConnection.py
@@ -358,7 +358,7 @@ class SMTPConnection(SSLConnection):
                 
         # Send a STARTTLS
         self._sock.send('STARTTLS\r\n')
-        if 'Ready to start TLS'  not in self._sock.recv(2048): 
+        if '220'  not in self._sock.recv(2048): 
             raise StartTLSError(self.ERR_NO_SMTP_STARTTLS)
 
 


### PR DESCRIPTION
Fix of STARTTLS response parser to just look at the response code. This fixes issue 47.

https://github.com/iSECPartners/sslyze/issues/47
