### PR TITLE
Used port of provided target when connecting

### DIFF
--- a/plugins/PluginHSTS.py
+++ b/plugins/PluginHSTS.py
@@ -56,7 +56,7 @@ class PluginHSTS(PluginBase.PluginBase):
         hsts_supported = False
         hsts_timeout = ""
         (host, addr, port, sslVersion) = target
-        connection = httplib.HTTPSConnection(host)
+        connection = httplib.HTTPSConnection(host, port)
         try:
             connection.connect()
             connection.request("HEAD", "/", headers={"Connection": "close"})


### PR DESCRIPTION
The provided port of the target isn't being used when the HSTS plugin creates a new HTTPS connection to it. It's defaulting to 443.
