### PR TITLE
export: added JSON support

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Key features include:
 * Server certificate validation and revocation checking through OCSP stapling
 * Support for StartTLS handshakes on SMTP, XMPP, LDAP, POP, IMAP, RDP and FTP
 * Support for client certificates when scanning servers that perform mutual authentication
-* XML output to further process the scan results
+* XML/JSON output to further process the scan results
 * And much more !
 
 

--- a/utils/CommandLineParser.py
+++ b/utils/CommandLineParser.py
@@ -162,6 +162,14 @@ class CommandLineParser():
             dest='xml_file',
             default=None)
 
+        # JSON output
+        self._parser.add_option(
+            '--json_out',
+            help='Writes the scan results as JSON document to the file JSON_FILE.',
+            dest='json_file',
+            default=None)
+
+
         # Read targets from input file
         self._parser.add_option(
             '--targets_in',


### PR DESCRIPTION
JSON support as mentioned in issue #23.
- It uses the XML document as the source and converts it to JSON. It uses 'xmltodict' to convert the final version of the document to JSON.
- Added new option to settings to define filename for the JSON output.
