### PR TITLE
Allow user to override certinfo on the command line when using --regular

### DIFF
--- a/utils/CommandLineParser.py
+++ b/utils/CommandLineParser.py
@@ -113,12 +113,15 @@ class CommandLineParser():
             if getattr(args_command_list, 'regular'):
                 setattr(args_command_list, 'regular', False)
                 for cmd in self.REGULAR_CMD:
-                    setattr(args_command_list, cmd, True)
-                setattr(args_command_list, 'certinfo', 'basic') # Special case
+                    if cmd=="certinfo":
+                        # Allow user to override certinfo when using --regular
+                        if getattr(args_command_list, 'certinfo') is None:
+                            setattr(args_command_list, 'certinfo', 'basic') # Special case
+                    else: 
+                        setattr(args_command_list, cmd, True)
 
         # Create the shared_settings object from looking at the command line
         shared_settings = self._process_parsing_results(args_command_list)
-
         return args_command_list, args_target_list, shared_settings
 
 


### PR DESCRIPTION
When a user specifies --regular on the command line, CommandLineParser.py parses the options, and then overrides them with the --regular settings, possibly clobbering the user's certinfo setting. Instead, we keep the certinfo setting if it's on the command-line, or just use 'basic' otherwise.
