### PR TITLE
PluginSessionResumption - correcty handle empty session-id

### DIFF
--- a/plugins/PluginSessionResumption.py
+++ b/plugins/PluginSessionResumption.py
@@ -212,9 +212,12 @@ class PluginSessionResumption(PluginBase.PluginBase):
 
         session1 = self._resume_ssl_session(target)
         try: # Recover the session ID
-            session1_id = self._extract_session_id(session1)
+            session1_id = self._extract_session_id(session1).strip()
         except IndexError:
             return False, 'Session ID not assigned'
+
+        if session1_id == '':
+            return False, 'Session ID empty'
 
         # Try to resume that SSL session
         session2 = self._resume_ssl_session(target, session1)


### PR DESCRIPTION
Sometimes the Session-ID is simply empty. In this case sslyze will incorrectly report that session-id reuse is enabled because session1_id == session2_id.
